### PR TITLE
refactor(errors): use thiserror to provide more context-rich errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "serde 1.0.133",
  "serde_json 1.0.74",
  "sha2 0.10.1",
+ "thiserror",
  "tokio",
  "tokio-test",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ bs58 = "0.4.0"
 ed25519-dalek = { version = "1.0.1", optional = true }
 avro = "0.2.1"
 reqwest = { version = "0.11.9", features = [ "json" ] }
+thiserror = "1.0.30"
 
 [dev-dependencies]
 tokio-test = "*"

--- a/src/bundlr.rs
+++ b/src/bundlr.rs
@@ -54,13 +54,14 @@ impl<T: Signer> Bundlr<T> {
         match response {
             Ok(r) => {
                 if !r.status().is_success() {
-                    return Err(BundlrError::ResponseError);
+                    let msg = format!("Status: {}", r.status());
+                    return Err(BundlrError::ResponseError(msg));
                 };
                 r.json::<Value>()
                     .await
-                    .map_err(|_| BundlrError::ResponseError)
+                    .map_err(|e| BundlrError::ResponseError(e.to_string()))
             }
-            Err(_) => Err(BundlrError::ResponseError),
+            Err(_) => Err(BundlrError::ResponseError("Unknown Error".to_string())),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,28 @@
-use derive_more::{Display, Error};
+use thiserror::Error;
 
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Error)]
 pub enum BundlrError {
+    #[error("Invalid headers provided.")]
     InvalidHeaders,
+
+    #[error("Invalid signer type used.")]
     InvalidSignerType,
+
+    #[error("Invalid presence byte.")]
     InvalidPresenceByte,
+
+    #[error("No bytes left.")]
     NoBytesLeft,
+
+    #[error("Invalid tag encoding.")]
     InvalidTagEncoding,
-    FsError,
+
+    #[error("File system error: {0}")]
+    FsError(String),
+
+    #[error("Invalid signature.")]
     InvalidSignature,
-    ResponseError
+
+    #[error("Response failed with the following error: {0}")]
+    ResponseError(String),
 }

--- a/src/verify/file.rs
+++ b/src/verify/file.rs
@@ -17,8 +17,8 @@ use std::{
 };
 
 impl From<std::io::Error> for BundlrError {
-    fn from(_: std::io::Error) -> Self {
-        BundlrError::FsError
+    fn from(e: std::io::Error) -> Self {
+        BundlrError::FsError(e.to_string())
     }
 }
 


### PR DESCRIPTION
This PR does a minor refactor of the BundlrError enum to use the `thiserror` library to provide more context rich errors.

The change goes from opaque errors such as the ResponseError:
![Selection_603](https://user-images.githubusercontent.com/1684605/151235580-8f4a8105-ef92-4745-9651-e9e80a0edcca.png)

to something that provides better context:
![Selection_602](https://user-images.githubusercontent.com/1684605/151235761-e9d0e1f4-4ee4-44cc-9ad0-8b094481aeb4.png)

