### PR TITLE
chore: add cargo-release config file

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,2 @@
+allow-branch = ["master"]
+sign-commit = true


### PR DESCRIPTION
This ensures commits are signed and only released from the master branch when [cargo-release](https://github.com/crate-ci/cargo-release) is used for creating new releases.