### PR TITLE
Refactor/arweave feat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ derive_builder = "0.10.2"
 derive_more = "0.99.17"
 ed25519-dalek = { version = "1.0.1", optional = true }
 futures = "0.3.19"
-jsonwebkey = { version = "0.3.4", features = [ "pkcs-convert" ] }
+jsonwebkey = { version = "0.3.4", optional = true, features = [ "pkcs-convert" ] }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
@@ -29,13 +29,13 @@ primitive-types = "0.11.1"
 rand = "0.8.5"
 reqwest = "0.11.11"
 ring = "0.16.20"
-rsa = "0.6.1"
+rsa = { version = "0.6.1", optional = true }
 secp256k1 = { version = "0.22.1", optional = true, features = [ "recovery" ] }
 serde = "1.0.132"
 serde_json = "1.0.73"
 sha2 = "0.10.2"
 thiserror = "1.0.30"
-tokio = { version = "1.15.0", features = [ "fs" ]}
+tokio = { version = "1.14.0", features = [ "fs" ]}
 tokio-util = "0.6.9"
 web3 = { version = "0.18.0", optional = true }
 
@@ -48,7 +48,8 @@ default-features = false
 features = ["user-hooks"]
 
 [features]
-default = ["solana", "ethereum", "erc20", "cosmos"]
+default = ["solana", "ethereum", "erc20", "cosmos", "arweave"]
+arweave = ["rsa", "jsonwebkey"]
 cosmos = ["secp256k1"]
 erc20 = ["secp256k1", "web3"]
 ethereum = ["secp256k1", "web3"]

--- a/src/deep_hash.rs
+++ b/src/deep_hash.rs
@@ -57,7 +57,7 @@ pub async fn deep_hash(chunk: DeepHashChunk) -> Result<Bytes, BundlrError> {
 
             let acc = sha384hash(tag.into());
 
-            return deep_hash_chunks(chunks, acc).await;
+            deep_hash_chunks(chunks, acc).await
         }
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,7 +3,10 @@ use derive_more::Display;
 use num_derive::FromPrimitive;
 use std::panic;
 
-use crate::{ArweaveSigner, Verifier};
+use crate::Verifier;
+
+#[cfg(feature = "arweave")]
+use crate::ArweaveSigner;
 
 #[cfg(any(feature = "solana", feature = "algorand"))]
 use crate::Ed25519Signer;
@@ -39,6 +42,7 @@ impl Config {
 impl SignerMap {
     pub fn get_config(&self) -> Config {
         match *self {
+            #[cfg(feature = "arweave")]
             SignerMap::Arweave => Config {
                 sig_length: 512,
                 pub_length: 512,
@@ -65,6 +69,7 @@ impl SignerMap {
 
     pub fn verify(&self, pk: &[u8], message: &[u8], signature: &[u8]) -> Result<bool, BundlrError> {
         match *self {
+            #[cfg(feature = "arweave")]
             SignerMap::Arweave => ArweaveSigner::verify(
                 Bytes::copy_from_slice(pk),
                 Bytes::copy_from_slice(message),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,22 @@
 extern crate derive_builder;
 
+mod bundlr;
+mod index;
+mod signers;
+mod transaction;
+
 pub mod deep_hash;
 pub mod deep_hash_sync;
 pub mod error;
-mod index;
-mod signers;
 pub mod tags;
-mod transaction;
-// pub mod stream;
-mod bundlr;
 pub mod verify;
 
-pub use signers::arweave::ArweaveSigner;
+pub use bundlr::Bundlr;
+pub use signers::signer::{Signer, Verifier};
 pub use transaction::BundlrTx;
+
+#[cfg(feature = "arweave")]
+pub use signers::arweave::ArweaveSigner;
 
 #[cfg(any(feature = "solana", feature = "algorand"))]
 pub use signers::ed25519::Ed25519Signer;
@@ -22,6 +26,3 @@ pub use signers::secp256k1::Secp256k1Signer;
 
 #[cfg(feature = "cosmos")]
 pub use signers::cosmos::CosmosSigner;
-
-pub use bundlr::Bundlr;
-pub use signers::signer::{Signer, Verifier};

--- a/src/signers/arweave.rs
+++ b/src/signers/arweave.rs
@@ -1,14 +1,13 @@
 use crate::error::BundlrError;
 use bytes::Bytes;
 use data_encoding::BASE64URL;
+use jsonwebkey as jwk;
 use rand::thread_rng;
 use rsa::{
     pkcs8::{DecodePrivateKey, DecodePublicKey},
     PaddingScheme, PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey,
 };
 use sha2::Digest;
-
-extern crate jsonwebkey as jwk;
 
 use super::signer::{Signer, Verifier};
 

--- a/src/signers/mod.rs
+++ b/src/signers/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "arweave")]
 pub mod arweave;
 #[cfg(feature = "cosmos")]
 pub mod cosmos;


### PR DESCRIPTION
This PR puts the arweave module and signer behind a feature but adds it to the default features list. The Metaplex Sugar CLI relies on Solana libraries that have a `zeroize` dependency that is in conflict with the one used by `rsa` which is used by the `arweave` module. Fortunately, Sugar CLI does not use the arweave module at all so we can just disable default features and only use the one we need.