### PR TITLE
fix typo

### DIFF
--- a/src/transaction/bundlr.rs
+++ b/src/transaction/bundlr.rs
@@ -289,7 +289,7 @@ impl BundlrTx {
         verifier.verify(pub_key, &message, signature)
     }
 
-    pub fn get_signarure(&self) -> Vec<u8> {
+    pub fn get_signature(&self) -> Vec<u8> {
         self.signature.clone()
     }
 }

--- a/src/verify/file.rs
+++ b/src/verify/file.rs
@@ -42,7 +42,7 @@ pub async fn verify_file_bundle(filename: String) -> Result<Vec<Item>, BundlrErr
         match tx.verify().await {
             Err(_) => return Err(BundlrError::InvalidSignature),
             Ok(_) => {
-                let sig = tx.get_signarure();
+                let sig = tx.get_signature();
                 let item = Item {
                     tx_id: id,
                     signature: sig,


### PR DESCRIPTION
Fixes typo from `get_signarure` to `get_signature` in `BundlrTx`  impl.